### PR TITLE
Aded drops for terracotta_bricks with pickaxe

### DIFF
--- a/src/main/resources/data/blocksnack/loot_table/blocks/terracotta_bricks.json
+++ b/src/main/resources/data/blocksnack/loot_table/blocks/terracotta_bricks.json
@@ -1,0 +1,21 @@
+{
+    "type": "minecraft:block",
+    "pools": [
+        {
+            "bonus_roles": 0.0,
+            "conditions": [
+                {
+                    "condition": "minecraft:survives_explosion"
+                }
+            ],
+            "entries": [
+                {
+                    "type": "minecraft:item",
+                    "name": "blocksnack:terracotta_bricks"
+                }
+            ],
+            "rolls": 1.0
+        }
+    ],
+    "random_sequence": "blocksnack:blocks/terracotta_bricks"
+}

--- a/src/main/resources/data/minecraft/tags/block/mineable/pickaxe.json
+++ b/src/main/resources/data/minecraft/tags/block/mineable/pickaxe.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+        "blocksnack:terracotta_bricks"
+    ]
+}


### PR DESCRIPTION
Completed:
- Drop terracotta_bricks block item when terracotta_bricks block is destroyed.
Still To Do:
- Convert basic implementation to Data Gen method.
- Add colored terracotta_brick/terracotta_bricks.